### PR TITLE
try to fallback to unittest2 if using an older python version

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -7,6 +7,9 @@
 
 import unittest
 
+if not hasattr(unittest.TestCase, 'assertIsNotNone'):
+    import unittest2 as unittest
+
 from mock import Mock
 from requests import Request
 


### PR DESCRIPTION
Python 2.6 doesn't have unittest.TestCase.assertIsNotNone, among others.  If
we don't have it, try to import unittest2 as unittest.
