### PR TITLE
minor fixes (latest pep8 indent compat)

### DIFF
--- a/rauth/hook.py
+++ b/rauth/hook.py
@@ -72,8 +72,8 @@ class OAuth1Hook(object):
     oauth_verifier = None
 
     def __init__(self, consumer_key, consumer_secret, access_token=None,
-            access_token_secret=None, header_auth=False, signature=None,
-            default_oauth_callback=None):
+                 access_token_secret=None, header_auth=False, signature=None,
+                 default_oauth_callback=None):
         # consumer credentials
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret
@@ -112,12 +112,12 @@ class OAuth1Hook(object):
 
         # sign and add the signature to the request params
         request.oauth_params['oauth_signature'] = \
-                self.signature.sign(request,
-                                    self.consumer_secret,
-                                    self.access_token_secret)
+            self.signature.sign(request,
+                                self.consumer_secret,
+                                self.access_token_secret)
 
         request.params_and_data['oauth_signature'] = \
-                request.oauth_params['oauth_signature']
+            request.oauth_params['oauth_signature']
 
         if self.header_auth:
             # extract the domain for use as the realm
@@ -125,7 +125,7 @@ class OAuth1Hook(object):
             realm = urlunsplit((scheme, netloc, '/', '', ''))
 
             request.headers['Authorization'] = \
-                    self.auth_header(request.oauth_params, realm=realm)
+                self.auth_header(request.oauth_params, realm=realm)
         elif request.method == 'POST':
             content_type = 'application/x-www-form-urlencoded'
             request.headers['content-type'] = content_type

--- a/rauth/oauth.py
+++ b/rauth/oauth.py
@@ -64,7 +64,7 @@ class SignatureMethod(object):
 
             # we concatenate the respective dicts
             params_and_data = \
-                    dict(request.params.items() + request.data.items())
+                dict(request.params.items() + request.data.items())
 
             normalized = []
             for k, v in params_and_data.items():

--- a/rauth/service.py
+++ b/rauth/service.py
@@ -150,20 +150,20 @@ class OflyService(Request):
         now = datetime.utcnow()
         milliseconds = self._micro_to_milliseconds(now.microsecond)
         time_format = self.TIMESTAMP_FORMAT.format(milliseconds)
-        ofly_params = \
-                {'oflyAppId': self.consumer_key,
-                 'oflyHashMeth': 'SHA1',
-                 'oflyTimestamp': now.strftime(time_format)}
+        ofly_params = {'oflyAppId': self.consumer_key,
+                       'oflyHashMeth': 'SHA1',
+                       'oflyTimestamp': now.strftime(time_format)}
 
         # select only the path for signing
         url_path = urlsplit(url).path
 
-        signature_base_string = self.consumer_secret \
-                                + url_path \
-                                + '?' \
-                                + self._sort_params(params) \
-                                + '&' \
-                                + self._sort_params(ofly_params)
+        signature_base_string = \
+            self.consumer_secret \
+            + url_path \
+            + '?' \
+            + self._sort_params(params) \
+            + '&' \
+            + self._sort_params(ofly_params)
 
         params['oflyApiSig'] = hashlib.sha1(signature_base_string).hexdigest()
 
@@ -210,10 +210,9 @@ class OflyService(Request):
 
         header_auth = kwargs.get('header_auth', False)
         if header_auth:
-            params, headers = \
-                    self._sha1_sign_params(url,
-                                           header_auth,
-                                           **params)
+            params, headers = self._sha1_sign_params(url,
+                                                     header_auth,
+                                                     **params)
 
             response = self.session.request(method,
                                             url + '?' + params,
@@ -267,7 +266,7 @@ class OAuth2Service(Request):
     :param access_token: An access token, defaults to None.
     '''
     def __init__(self, name, consumer_key, consumer_secret, access_token_url,
-            authorize_url, access_token=None):
+                 authorize_url, access_token=None):
         self.name = name
 
         self.consumer_key = consumer_key
@@ -392,7 +391,7 @@ class OAuth1Service(Request):
     :param header_auth: Authenication via header, defaults to False.
     '''
     def __init__(self, name, consumer_key, consumer_secret, request_token_url,
-            access_token_url, authorize_url, header_auth=False):
+                 access_token_url, authorize_url, header_auth=False):
         self.name = name
 
         self.consumer_key = consumer_key
@@ -428,9 +427,8 @@ class OAuth1Service(Request):
         :param method: A string representation of the HTTP method to be used.
         :param \*\*kwargs: Optional arguments. Same as Requests.
         '''
-        auth_session = \
-                self._construct_session(header_auth=self.header_auth,
-                                        default_oauth_callback='oob')
+        auth_session = self._construct_session(header_auth=self.header_auth,
+                                               default_oauth_callback='oob')
 
         response = auth_session.request(method,
                                         self.request_token_url,
@@ -480,10 +478,10 @@ class OAuth1Service(Request):
         request_token = kwargs.pop('request_token')
         request_token_secret = kwargs.pop('request_token_secret')
 
-        auth_session = self._construct_session(
-                                access_token=request_token,
-                                access_token_secret=request_token_secret,
-                                header_auth=self.header_auth)
+        auth_session = \
+            self._construct_session(access_token=request_token,
+                                    access_token_secret=request_token_secret,
+                                    header_auth=self.header_auth)
 
         response = auth_session.request(method,
                                         self.access_token_url,
@@ -492,7 +490,7 @@ class OAuth1Service(Request):
         return Response(response)
 
     def get_authenticated_session(self, access_token, access_token_secret,
-            header_auth=False):
+                                  header_auth=False):
         '''Returns an authenticated Requests session utilizing the hook.
 
         :param access_token: The access token as returned by

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -7,13 +7,13 @@
 
 from base import RauthTestCase
 from rauth.oauth import (HmacSha1Signature, RsaSha1Signature,
-        PlaintextSignature)
+                         PlaintextSignature)
 
 from urllib import urlencode
 
 
 class OAuthTestHmacSha1Case(RauthTestCase):
-    def test_hamcsha1_signature(self):
+    def test_hmacsha1_signature(self):
         self.request.params = {'foo': 'bar'}
         oauth_signature = HmacSha1Signature().sign(self.request,
                                                    self.hook.consumer_key,
@@ -25,14 +25,14 @@ class OAuthTestHmacSha1Case(RauthTestCase):
         # params as a dict
         self.request.params = {'foo': 'bar'}
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('foo=bar',  normalized)
 
         # params as a dict with URL encodable chars
         self.request.params_and_data = {}
         self.request.params = {'foo+bar': 'baz'}
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('foo%2Bbar=baz',  normalized)
         self.assertTrue('+' not in normalized)
 
@@ -40,14 +40,14 @@ class OAuthTestHmacSha1Case(RauthTestCase):
         self.request.params_and_data = {}
         self.request.params = urlencode({'foo': 'bar'})
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('foo=bar',  normalized)
 
         # params as a string with URL encodable chars
         self.request.params_and_data = {}
         self.request.params = urlencode({'foo+bar': 'baz'})
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('foo%2Bbar=baz',  normalized)
         self.assertTrue('+' not in normalized)
 
@@ -56,28 +56,28 @@ class OAuthTestHmacSha1Case(RauthTestCase):
         self.request.params = {'a': 'b'}
         self.request.data = {'foo': 'bar'}
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('a=b&foo=bar',  normalized)
 
     def test_normalize_request_parameters_data(self):
         # data as a dict
         self.request.data = {'foo': 'bar'}
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('foo=bar',  normalized)
 
         # data as a dict with URL encodable chars
         self.request.params_and_data = {}
         self.request.data = {'foo+bar': 'baz'}
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('foo%2Bbar=baz',  normalized)
         self.assertTrue('+' not in normalized)
 
         # data as a string with URL encodable chars
         self.request.data = urlencode({'foo+bar': 'baz'})
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('foo%2Bbar=baz',  normalized)
         self.assertTrue('+' not in normalized)
 
@@ -86,7 +86,7 @@ class OAuthTestHmacSha1Case(RauthTestCase):
         self.request.params = urlencode({'a': 'b'})
         self.request.data = urlencode({'foo': 'bar'})
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         # this also demonstrates sorting
         self.assertEqual('a=b&foo=bar',  normalized)
 
@@ -95,7 +95,7 @@ class OAuthTestHmacSha1Case(RauthTestCase):
         self.request.params = urlencode({'a': 'b'})
         self.request.data = {'foo': 'bar'}
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('a=b&foo=bar',  normalized)
 
     def test_normalize_request_parameters_data_string(self):
@@ -103,7 +103,7 @@ class OAuthTestHmacSha1Case(RauthTestCase):
         self.request.params = {'a': 'b'}
         self.request.data = urlencode({'foo': 'bar'})
         normalized = \
-                HmacSha1Signature()._normalize_request_parameters(self.request)
+            HmacSha1Signature()._normalize_request_parameters(self.request)
         self.assertEqual('a=b&foo=bar',  normalized)
 
     def test_normalize_request_parameters_whitespace(self):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -21,17 +21,16 @@ class OflyServiceTestCase(RauthTestCase):
         RauthTestCase.setUp(self)
 
         # mock service for testing
-        service = OflyService(
-                'example',
-                consumer_key='123',
-                consumer_secret='456',
-                authorize_url='http://example.com/authorize')
+        service = OflyService('example',
+                              consumer_key='123',
+                              consumer_secret='456',
+                              authorize_url='http://example.com/authorize')
         self.service = service
 
     def test_get_authorize_url(self):
         url = self.service.get_authorize_url(
-                remote_user='foobar',
-                redirect_uri='http://example.com/redirect')
+            remote_user='foobar',
+            redirect_uri='http://example.com/redirect')
         self.assertIn('ApiSig=', url)
         self.assertIn('oflyAppId=123', url)
         self.assertIn('oflyCallbackUrl=http://example.com/redirect', url)
@@ -112,27 +111,27 @@ class OAuth2ServiceTestCase(RauthTestCase):
 
         # mock service for testing
         service = OAuth2Service(
-                'example',
-                consumer_key='123',
-                consumer_secret='456',
-                access_token_url='http://example.com/access_token',
-                authorize_url='http://example.com/authorize')
+            'example',
+            consumer_key='123',
+            consumer_secret='456',
+            access_token_url='http://example.com/access_token',
+            authorize_url='http://example.com/authorize')
         self.service = service
 
     def test_init_with_access_token(self):
         service = OAuth2Service(
-                'example',
-                consumer_key='123',
-                consumer_secret='456',
-                access_token_url='http://example.com/access_token',
-                authorize_url='http://example.com/authorize',
-                access_token='321')
+            'example',
+            consumer_key='123',
+            consumer_secret='456',
+            access_token_url='http://example.com/access_token',
+            authorize_url='http://example.com/authorize',
+            access_token='321')
         self.assertEqual(service.access_token, '321')
 
     def test_get_authorize_url(self):
         authorize_url = self.service.get_authorize_url()
         expected_url = \
-                'http://example.com/authorize?response_type=code&client_id=123'
+            'http://example.com/authorize?response_type=code&client_id=123'
         self.assertEqual(expected_url, authorize_url)
 
     def test_get_authorize_url_response_type(self):
@@ -145,15 +144,15 @@ class OAuth2ServiceTestCase(RauthTestCase):
     def test_get_access_token(self, mock_request):
         mock_request.return_value = self.response
         response = \
-                self.service.get_access_token(data=dict(code='4242')).content
+            self.service.get_access_token(data=dict(code='4242')).content
         self.assertEqual(response['access_token'], '321')
 
     @patch.object(requests.Session, 'request')
     def test_get_access_token_params(self, mock_request):
         mock_request.return_value = self.response
         response = \
-                self.service.get_access_token('GET',
-                                              params=dict(code='4242')).content
+            self.service.get_access_token('GET',
+                                          params=dict(code='4242')).content
         self.assertEqual(response['access_token'], '321')
 
     @patch.object(requests.Session, 'request')
@@ -170,16 +169,14 @@ class OAuth2ServiceTestCase(RauthTestCase):
     def test_get_access_token_grant_type(self, mock_request):
         mock_request.return_value = self.response
         data = dict(code='4242', grant_type='refresh_token')
-        response = \
-            self.service.get_access_token(data=data).content
+        response = self.service.get_access_token(data=data).content
         self.assertEqual(response['access_token'], '321')
 
     @patch.object(requests.Session, 'request')
     def test_get_access_token_client_credentials(self, mock_request):
         mock_request.return_value = self.response
         data = dict(grant_type='client_credentials')
-        response = \
-            self.service.get_access_token(data=data).content
+        response = self.service.get_access_token(data=data).content
         self.assertEqual(response['access_token'], '321')
 
     @patch.object(requests.Session, 'request')
@@ -189,7 +186,7 @@ class OAuth2ServiceTestCase(RauthTestCase):
         mock_request.return_value = self.response
         response = self.service.request('GET',
                                         'http://example.com/endpoint',
-                                         access_token='321').content
+                                        access_token='321').content
         self.assertEqual(response['status'], 'ok')
 
     @patch.object(requests.Session, 'request')
@@ -237,7 +234,7 @@ class OAuth2ServiceTestCase(RauthTestCase):
         with self.assertRaises(Exception) as e:
             self.service.request('GET',
                                  'http://example.com/endpoint',
-                                  access_token='321')
+                                 access_token='321')
             self.assertEqual('Response not OK!', str(e))
 
 
@@ -247,12 +244,12 @@ class OAuth1ServiceTestCase(RauthTestCase):
 
         # mock service for testing
         service = OAuth1Service(
-                'example',
-                consumer_key='123',
-                consumer_secret='456',
-                request_token_url='http://example.com/request_token',
-                access_token_url='http://example.com/access_token',
-                authorize_url='http://example.com/authorize')
+            'example',
+            consumer_key='123',
+            consumer_secret='456',
+            request_token_url='http://example.com/request_token',
+            access_token_url='http://example.com/access_token',
+            authorize_url='http://example.com/authorize')
         self.service = service
 
         # mock response content
@@ -271,7 +268,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
         mock_request.return_value = self.response
 
         request_token, request_token_secret = \
-                self.service.get_request_token('GET')
+            self.service.get_request_token('GET')
         self.assertEqual(request_token, '123')
         self.assertEqual(request_token_secret, '456')
 
@@ -280,7 +277,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
         mock_request.return_value = self.response
 
         request_token, request_token_secret = \
-                self.service.get_request_token('POST')
+            self.service.get_request_token('POST')
         self.assertEqual(request_token, '123')
         self.assertEqual(request_token_secret, '456')
 
@@ -290,7 +287,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
 
         self.service.header_auth = True
         request_token, request_token_secret = \
-                self.service.get_request_token('POST')
+            self.service.get_request_token('POST')
         self.assertEqual(request_token, '123')
         self.assertEqual(request_token_secret, '456')
 
@@ -315,7 +312,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
         authorize_url = self.service.get_authorize_url(request_token='123',
                                                        additional_param=val)
         expected_url = 'http://example.com/authorize?oauth_token=123&' \
-                'additional_param=http%3A%2F%2Fexample.com%2Fsomething'
+                       'additional_param=http%3A%2F%2Fexample.com%2Fsomething'
         self.assertEqual(expected_url, authorize_url)
 
     @patch.object(requests.Session, 'request')
@@ -332,7 +329,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
     def test_get_access_token_bad_response(self, mock_request):
         self.response.ok = False
         self.response.content = \
-                json.dumps(dict(error='Oops, something went wrong :('))
+            json.dumps(dict(error='Oops, something went wrong :('))
         mock_request.return_value = self.response
 
         response = self.service.get_access_token('GET',
@@ -456,7 +453,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
         self.response.content = 'oauth_token=\xc3\xbc&oauth_token_secret=b'
 
         request_token, request_token_secret = \
-                self.service.get_request_token('GET')
+            self.service.get_request_token('GET')
         self.assertEqual(request_token, u'\xfc')
         self.assertEqual(request_token_secret, 'b')
 
@@ -467,7 +464,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
         self.response.content = u'oauth_token=\xfc&oauth_token_secret=b'
 
         request_token, request_token_secret = \
-                self.service.get_request_token('GET')
+            self.service.get_request_token('GET')
         self.assertEqual(request_token, u'\xfc')
         self.assertEqual(request_token_secret, 'b')
 
@@ -478,7 +475,7 @@ class OAuth1ServiceTestCase(RauthTestCase):
         self.response.content = u'oauth_token=ü&oauth_token_secret=b'
 
         request_token, request_token_secret = \
-                self.service.get_request_token('GET')
+            self.service.get_request_token('GET')
         self.assertEqual(request_token, u'\xfc')
         self.assertEqual(request_token_secret, 'b')
 


### PR DESCRIPTION
pep8 v1.3 and later have a more strict indentation rules. This commit fixes 40+ errors (E126, E127, E128).
