### PR TITLE
Invalid oflyApiSig when no params are passed

### DIFF
--- a/rauth/service.py
+++ b/rauth/service.py
@@ -160,10 +160,14 @@ class OflyService(Request):
         signature_base_string = \
             self.consumer_secret \
             + url_path \
-            + '?' \
-            + self._sort_params(params) \
-            + '&' \
-            + self._sort_params(ofly_params)
+            + '?'
+
+        # only append params if there are any, to avoid a leading ampersand
+        sorted_params = self._sort_params(params)
+        if len(sorted_params) > 0:
+             signature_base_string += sorted_params + '&'
+
+        signature_base_string += self._sort_params(ofly_params)
 
         params['oflyApiSig'] = hashlib.sha1(signature_base_string).hexdigest()
 


### PR DESCRIPTION
Consider the following case in `OflyService._sha1_sign_params` ([source](https://github.com/litl/rauth/blob/6780e21795d3c53ebd3cc3824b973a4dd2454766/rauth/service.py#L160-166)):

If the `params` argument passed to `_sha1_sign_params` is empty, `_sort_params` will return an empty string at [line 164](https://github.com/litl/rauth/blob/6780e21795d3c53ebd3cc3824b973a4dd2454766/rauth/service.py#L164). This will result in an invalid query string (an ampersand immediately after the question mark, e.g. `...?&...`).

This is obviously resulting in an invalid hash. I have confirmed the problem on the Shutterfly API.

For the curious: the [Shutterfly API](http://www.shutterfly.com/documentation/OflyCallSignature.sfly) provides a detailed description of how to generate the hash. Look under the heading **Signature Generation Details**.
