### PR TITLE
Checking that the LinkedIn update has currentShare field

### DIFF
--- a/AUTHORS.markdown
+++ b/AUTHORS.markdown
@@ -29,4 +29,5 @@ Add yourself as a contributor!
 
 * [Justin Barber](https://github.com/barberj)
 * [Dave Stoll](https://github.com/netdude78)
+* [Marek Rei](https://github.com/marekrei)
 * (your name here)

--- a/examples/linkedin-updates.py
+++ b/examples/linkedin-updates.py
@@ -38,6 +38,9 @@ response = linkedin.get(
 updates = response.content
 
 for i, update in enumerate(updates['values'], 1):
+    if 'currentShare' not in update['updateContent']['person']:
+        print '{0}. {1}'.format(i, update['updateKey'])
+        continue
     current_share = update['updateContent']['person']['currentShare']
     person = current_share['author']['firstName'].encode('utf-8') + ' '
     person += current_share['author']['lastName'].encode('utf-8')


### PR DESCRIPTION
I looked into why I was getting an error with the linkedin-updates.py example. Apparently the API reponse from LinkedIn doesn't always contain the currentShare field that is used in the example. This is an update from my stream:

```
{'updateKey': 'key-removed-just-in-case', 'isCommentable': True, 'isLiked': False, 'timestamp': 1349354311405L, 'numLikes': 0, 'isLikable': True, 'updateType': 'SHAR', 'updateContent': {'person': {'lastName': 'private', 'id': 'private', 'firstName': 'private'}}, 'updateComments': {'_total': 0}}, 
```

And it was causing the error:

```
Traceback (most recent call last):
  File "linkedin-updates.py", line 41, in <module>
    current_share = update['updateContent']['person']['currentShare']
KeyError: 'currentShare'
```

The code now checks whether the field exists and prints the update key if it doesn't. I considered not printing anything, but that messes up the numbering.
Also added myself as an author. :)

Cheers
