### PR TITLE
set up tox for cross-version testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist=py33,py27,pypy
+
+[testenv]
+commands=./run-tests.sh
+deps=
+	-r{toxinidir}/requirements.txt


### PR DESCRIPTION
tox is a tool which can automate cross-version testing. To use here, you will need to 'pip install tox' either in a virtualenv you use to work, or in the system python. Then at the location of tox.ini, run 'tox'. Per this ini, this will create clean virtualenvs (under .tox/), install requirements listed in requirements.txt in those virtualenvs, install rauth, and then run the exist test run script in each virtualenv. Individual virtualenvs can be selected instead of running all at once, e.g. with 'tox -p py27'
