### PR TITLE
fixes issue #102 and bumbs requests version to 1.2.3

### DIFF
--- a/rauth/utils.py
+++ b/rauth/utils.py
@@ -68,8 +68,6 @@ class CaseInsensitiveDict(cidict):
             key = key.lower()
 
         super(CaseInsensitiveDict, self).setdefault(key, default)
-        self._clear_lower_keys()
 
     def update(self, d):
         super(CaseInsensitiveDict, self).update(self._get_lowered_d(d))
-        self._clear_lower_keys()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ mock==1.0.1
 nose==1.2.1
 pep8==1.4.2
 pyflakes==0.6.1
-requests==1.2.0
+requests==1.2.3
 unittest2==0.5.1
 yanc==0.2.3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == 'test':
     status >>= 8
     sys.exit(status)
 
-install_requires = ['requests==1.2.0']
+install_requires = ['requests==1.2.3']
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     install_requires.append('unittest2>=0.5.1')
 


### PR DESCRIPTION
The CaseInsensitiveDict no longer stores a _lower_keys cache, so simply removing the calls to _clear_lower_keys() fixes this issue.
