### PR TITLE
expose token responses

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -32,4 +32,5 @@ Add yourself as a contributor!
 * [Marek Rei](https://github.com/marekrei)
 * [Kieron Briggs](https://github.com/kbriggs)
 * [Tatsuji Tsuchiya](https://github.com/ta2xeo)
+* [Ken Koontz](https://github.com/kennethkoontz)
 * (your name here)

--- a/tests/test_service_oauth1.py
+++ b/tests/test_service_oauth1.py
@@ -308,6 +308,13 @@ class OAuth1ServiceTestCase(RauthTestCase, RequestMixin, ServiceMixin,
         s = self.service.get_auth_session('foo', 'bar')
         self.assertIsInstance(s, OAuth1Session)
 
+    def test_get_auth_session_with_request_token_response(self):
+        resp = 'oauth_token=foo&oauth_token_secret=bar'
+        self.response.content = resp
+        self.service.request_token_response = 'ok'
+        s = self.service.get_auth_session('foo', 'bar')
+        self.assertEqual(s.request_token_response, 'ok')
+
     def test_pickle_session(self):
         session = pickle.loads(pickle.dumps(self.session))
 

--- a/tests/test_service_oauth2.py
+++ b/tests/test_service_oauth2.py
@@ -138,6 +138,12 @@ class OAuth2ServiceTestCase(RauthTestCase, RequestMixin, ServiceMixin,
         s = self.service.get_auth_session()
         self.assertIsInstance(s, OAuth2Session)
 
+    def test_get_auth_session_with_access_token_response(self):
+        self.response.content = \
+            'access_token=123&expires_in=3600&refresh_token=456'
+        s = self.service.get_auth_session()
+        self.assertIsNotNone(s.access_token_response)
+
     def test_pickle_session(self):
         session = pickle.loads(pickle.dumps(self.session))
 


### PR DESCRIPTION
Covers https://github.com/litl/rauth/issues/129
- Exposed access_token and request_token responses for Oauth1 authentication.
- Exposed access_token response for Oauth2 authentication.
