### PR TITLE
resolves issue 148

### DIFF
--- a/rauth/session.py
+++ b/rauth/session.py
@@ -295,9 +295,9 @@ class OAuth2Session(RauthSession):
                         params={'format': 'json'})
         print r.json()
 
-    :param client_id: Client id.
+    :param client_id: Client id, defaults to `None`.
     :type client_id: str
-    :param client_secret: Client secret.
+    :param client_secret: Client secret, defaults to `None`
     :type client_secret: str
     :param access_token: Access token, defaults to `None`.
     :type access_token: str
@@ -316,8 +316,8 @@ class OAuth2Session(RauthSession):
                                           'access_token']
 
     def __init__(self,
-                 client_id,
-                 client_secret,
+                 client_id=None,
+                 client_secret=None,
                  access_token=None,
                  service=None,
                  access_token_key=None):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -90,6 +90,15 @@ class OAuth2SessionTestCase(RauthTestCase, RequestMixin):
         RauthTestCase.setUp(self)
 
         self.session = OAuth2Session('123', '345')
+        self.session_no_creds = OAuth2Session()
+
+    def test_with_credentials(self):
+        assert self.session.client_id == '123'
+        assert self.session.client_secret == '345'
+
+    def test_without_credentials(self):
+        assert self.session_no_creds.client_id is None
+        assert self.session_no_creds.client_secret is None
 
 
 class OflySessionTestCase(RauthTestCase, RequestMixin):


### PR DESCRIPTION
Proposed fix to resolve 148.
- Set defaults for client_id and client_secret to `None`
- Added smoke tests for session with/without credentials
