### PR TITLE
A change to throw actual exceptions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,4 +34,5 @@ Add yourself as a contributor!
 * [Tatsuji Tsuchiya](https://github.com/ta2xeo)
 * [Chris McGraw](https://github.com/mitgr81)
 * [Ken Koontz](https://github.com/kennethkoontz)
+* [Michael Stella](https://github.com/alertedsnake)
 * (your name here)

--- a/rauth/service.py
+++ b/rauth/service.py
@@ -213,6 +213,7 @@ class OAuth1Service(Service):
         self.request_token_response = session.request(method,
                                                       self.request_token_url,
                                                       **kwargs)
+        self.request_token_response.raise_for_status()
         return self.request_token_response
 
     def get_request_token(self,
@@ -289,6 +290,7 @@ class OAuth1Service(Service):
         self.access_token_response = session.request(method,
                                                      self.access_token_url,
                                                      **kwargs)
+        self.access_token_response.raise_for_status()
         return self.access_token_response
 
     def get_access_token(self,
@@ -516,6 +518,7 @@ class OAuth2Service(Service):
         self.access_token_response = session.request(method,
                                                      self.access_token_url,
                                                      **kwargs)
+        self.access_token_response.raise_for_status()
         return self.access_token_response
 
     def get_access_token(self,


### PR DESCRIPTION
When we're doing OAuth and the response code isn't 200OK, why shouldn't we return a proper exception to the client?  Without doing this, we have to parse client response, and it may not be something reasonable.

I'd make a test case, but that would require a working web server which returns bad responses.
