### PR TITLE
all special characters should be percent encoded

### DIFF
--- a/rauth/utils.py
+++ b/rauth/utils.py
@@ -93,7 +93,7 @@ class OAuth1Auth(AuthBase):
     def _get_auth_header(self):
         ''' Constructs and returns an authentication header. '''
         realm = 'realm="{realm}"'.format(realm=self.realm)
-        params = ['{k}="{v}"'.format(k=k, v=quote(str(v)))
+        params = ['{k}="{v}"'.format(k=k, v=quote(str(v), safe=''))
                   for k, v in self.oauth_params.items()]
         return 'OAuth ' + ','.join([realm] + params)
 


### PR DESCRIPTION
python by default does not encode '/', we need to set the safe parameter of quote to disable that
