### PR TITLE
Upload file bug with oauth signing was fixed

### DIFF
--- a/rauth/session.py
+++ b/rauth/session.py
@@ -150,8 +150,8 @@ class OAuth1Session(RauthSession):
 
         entity_method = method.upper() in ENTITY_METHODS
         if entity_method and 'files' not in req_kwargs or \
-        req_kwargs['files'] is None:
-            req_kwargs['headers'].setdefault('Content-Type', FORM_URLENCODED)
+            req_kwargs['files'] is None:
+                req_kwargs['headers'].setdefault('Content-Type', FORM_URLENCODED)
 
         form_urlencoded = \
             req_kwargs['headers'].get('Content-Type') == FORM_URLENCODED


### PR DESCRIPTION
It was a mistake to set content-type = application/x-www-form-urlencoded by default, requests lib setup it dynamically if we have non-empty parameter "files". 

Original version didn't work with images (files) upload for example in Etsy API see https://www.etsy.com/developers/documentation/getting_started/images
