### PR TITLE
do not encode ~ character

### DIFF
--- a/rauth/oauth.py
+++ b/rauth/oauth.py
@@ -98,7 +98,7 @@ class SignatureMethod(object):
         all_normalized.sort()
 
         # finally encode the params as a string
-        return urlencode(all_normalized, True).replace('+', '%20')
+        return urlencode(all_normalized, True).replace('+', '%20').replace('%7E', '~')
 
 
 class HmacSha1Signature(SignatureMethod):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -94,6 +94,13 @@ class OAuthTestHmacSha1Case(RauthTestCase):
             ._normalize_request_parameters(self.oauth_params, req_kwargs)
         self.assertEqual('foo=bar%20baz', normalized)
 
+    def test_normalize_request_parameters_tilde(self):
+        req_kwargs = {'data': {'foo': 'bar~'},
+                      'headers': {'Content-Type': FORM_URLENCODED}}
+        normalized = HmacSha1Signature()\
+            ._normalize_request_parameters(self.oauth_params, req_kwargs)
+        self.assertEqual('foo=bar~', normalized)
+
     def test_sign_utf8_encoded_string(self):
         # in the event a string is already UTF-8
         req_kwargs = {u'params': {u'foo': u'bar'}}


### PR DESCRIPTION
See https://bugs.python.org/issue16285

Rather than use `quote_plus(, safe='~')` I just went with the existing `replace()` option. 