### PR TITLE
Bugfix for issue #195 (Python 3.6 support)

### DIFF
--- a/rauth/utils.py
+++ b/rauth/utils.py
@@ -21,13 +21,12 @@ def absolute_url(url):
 
 
 def parse_utf8_qsl(s):
-    d = dict(parse_qsl(s))
+    d = dict()
 
-    for k, v in d.items():  # pragma: no cover
+    for k, v in dict(parse_qsl(s)).items():  # pragma: no cover
         if not isinstance(k, bytes) and not isinstance(v, bytes):
             # skip this iteration if we have no keys or values to update
             continue
-        d.pop(k)
         if isinstance(k, bytes):
             k = k.decode('utf-8')
         if isinstance(v, bytes):


### PR DESCRIPTION
Construct and return a new dict here instead of modifying in place. The Python 3.6 changes to the C dict implementation causes the keys to rearrange when modifying the dict while iterating, creating a flaw in the algorithm where a key gets skipped.