### PR TITLE
username KeyError fix

### DIFF
--- a/examples/facebook/facebook.py
+++ b/examples/facebook/facebook.py
@@ -91,7 +91,7 @@ def authorized():
     # the "me" response
     me = session.get('me').json()
 
-    User.get_or_create(me['username'], me['id'])
+    User.get_or_create(me['name'], me['id'])
 
     flash('Logged in as ' + me['name'])
     return redirect(url_for('index'))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1994, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/thyrst/Tools/EveFB/web.py", line 95, in authorized
    User.get_or_create(me['username'], me['id'])
KeyError: 'username'
```

The `username` key doesn't exist. And if you try to ask for `username` field, Facebook API returns error:
`(#12) username field is deprecated for versions v2.0 and higher`

In order to fix this you should use `name` field instead.