### PR TITLE
allow binary data in OAuth1Session.request

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,4 +34,5 @@ Add yourself as a contributor!
 * [Tatsuji Tsuchiya](https://github.com/ta2xeo)
 * [Chris McGraw](https://github.com/mitgr81)
 * [Ken Koontz](https://github.com/kennethkoontz)
+* [Markus Leuthold](https://github.com/githubkusi)
 * (your name here)

--- a/rauth/session.py
+++ b/rauth/session.py
@@ -225,7 +225,8 @@ class OAuth1Session(RauthSession):
         for oauth_param in OPTIONAL_OAUTH_PARAMS:
             if oauth_param in params:
                 oauth_params[oauth_param] = params.pop(oauth_param)
-            if oauth_param in data:
+
+            if type(data) is not bytes and oauth_param in data:
                 oauth_params[oauth_param] = data.pop(oauth_param)
 
             if params:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -56,6 +56,13 @@ class OAuth1SessionTestCase(RauthTestCase, RequestMixin):
         self.assert_ok(r)
 
     @patch.object(requests.Session, 'request')
+    def test_request_with_optional_data_as_binary(self, mock_request):
+        mock_request.return_value = self.response
+        data = bytes(1)
+        r = self.session.request('POST', 'http://example.com/', data=data)
+        self.assert_ok(r)
+
+    @patch.object(requests.Session, 'request')
     def test_request_with_optional_params_with_data(self, mock_request):
         mock_request.return_value = self.response
         data = {'oauth_callback': 'http://example.com/callback'}


### PR DESCRIPTION
In Python 2, binary data was handled just fine, because type bytes was
just a wrapper around str

    >>> data = bytes(1)
    >>> 'a' in data
    False

In Python 3, this gives an error

    >>> data = bytes(1)
    >>> 'a' in data
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: 'str' does not support the buffer interface

Example client code: Python 3 port of
https://github.com/marekrei/smuploader