### PR TITLE
docs: fix simple typo, initilize -> initialize

### DIFF
--- a/rauth/service.py
+++ b/rauth/service.py
@@ -465,7 +465,7 @@ class OAuth2Service(Service):
         authenticated session, otherwise an unauthenticated session object is
         generated. Returns an instance of :attr:`session_obj`..
 
-        :param token: A token with which to initilize the session.
+        :param token: A token with which to initialize the session.
         :type token: str
         '''
         if token is not None:


### PR DESCRIPTION
There is a small typo in rauth/service.py.

Should read `initialize` rather than `initilize`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md